### PR TITLE
sniffer can now be edited

### DIFF
--- a/traffic-dashboard/src/App.tsx
+++ b/traffic-dashboard/src/App.tsx
@@ -3,7 +3,7 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { PageTemplate } from "./components/page-template/page-template";
 import { routes } from "./constants/routes";
 import { RequestMetadataProvider } from "./context/requests-context";
-import { Home } from "./pages/home/home";
+import { Home } from "./pages/home/Home";
 import { NewRequest } from "./pages/new-request/new-request";
 import { RequestPage } from "./pages/request/request";
 import { Config } from "./pages/config/config";

--- a/traffic-dashboard/src/api/api.tsx
+++ b/traffic-dashboard/src/api/api.tsx
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { SnifferCreateConfig } from "../types/types";
+import { SnifferCreateConfig, } from "../types/types";
 
 export const createSniffer = (config: SnifferCreateConfig) => {
   return axios.post("/sharkio/sniffer", JSON.stringify(config), {
@@ -22,6 +22,13 @@ export const startSniffer = async (port: number) => {
 };
 export const deleteSniffer = async (port: number) => {
   return await axios.delete(`/sharkio/sniffer/${port}`);
+};
+export const editSniffer = async (newConfig: SnifferCreateConfig) => {
+  return axios.put(`/sharkio/sniffer/${newConfig.id}`, JSON.stringify(newConfig), {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
 };
 
 export const getRequests = () => {

--- a/traffic-dashboard/src/types/types.ts
+++ b/traffic-dashboard/src/types/types.ts
@@ -3,10 +3,12 @@ export type SnifferConfig = {
   downstreamUrl: string;
   isStarted: boolean;
   name: string;
+  id: string
 };
 
 export type SnifferCreateConfig = {
   port: number;
   downstreamUrl: string;
   name: string;
+  id: string
 };

--- a/traffic-sniffer/lib/request-metadata/sniffer-manager/sniffer-manager-controller.ts
+++ b/traffic-sniffer/lib/request-metadata/sniffer-manager/sniffer-manager-controller.ts
@@ -118,7 +118,7 @@ export class SnifferManagerController {
           if (sniffer !== undefined) {
             await sniffer
               .execute(url, method, invocation)
-              .catch((e) => console.error("erro while executing"));
+              .catch((e) => console.error("error while executing"));
             res.sendStatus(200);
           } else {
             res.sendStatus(404);
@@ -148,6 +148,29 @@ export class SnifferManagerController {
         }
       }
     );
+    this.app.put(
+      "/sharkio/sniffer/:existingId",
+      async (req: Request, res: Response) => {
+        const { existingId } = req.params;
+        const { port } = req.body
+
+        try {
+          const sniffer = this.snifferManager.getSnifferById(existingId);
+          // verify that there is no sniffer with the port you want to change to.
+          const isPortAlreadyExists = this.snifferManager.getSnifferById(port.toString());
+          if ((sniffer !== undefined && !isPortAlreadyExists) || +port === +existingId) {
+            this.snifferManager.editSniffer(existingId, req.body)
+            res.sendStatus(200);
+          } else if (!sniffer) {
+            res.sendStatus(404);
+          } else if (isPortAlreadyExists) {
+            res.sendStatus(403);
+          }
+        } catch (e: any) {
+          res.sendStatus(500);
+        }
+      }
+    )
   }
 
   start(port: number = 5012) {

--- a/traffic-sniffer/lib/request-metadata/sniffer-manager/sniffer-manager.ts
+++ b/traffic-sniffer/lib/request-metadata/sniffer-manager/sniffer-manager.ts
@@ -24,7 +24,7 @@ export class SnifferManager {
     const res = this.sniffers.find((sniffer: Sniffer) => {
       return sniffer.getPort() === port;
     });
-
+    
     return res;
   }
 
@@ -52,5 +52,21 @@ export class SnifferManager {
     }
 
     this.sniffers.splice(index, 1);
+  }
+  getSnifferById(id: string) {
+    const res = this.sniffers.find((sniffer: Sniffer) => {
+      return sniffer.getId() === id;
+    });
+
+    return res;
+  }
+  editSniffer(existingId: string, newConfig: SnifferConfig) {
+    const existingIndex = this.sniffers.findIndex((sniffer: Sniffer) => {
+      return sniffer.getId() === existingId;
+    });
+    if (this.sniffers[existingIndex].getIsStarted() === true) {
+      throw new Error("Cannot edit an active sniffer");
+    }
+    this.sniffers[existingIndex].editSniffer(newConfig)
   }
 }

--- a/traffic-sniffer/lib/request-metadata/sniffer/sniffer.ts
+++ b/traffic-sniffer/lib/request-metadata/sniffer/sniffer.ts
@@ -134,4 +134,12 @@ export class Sniffer {
   getMiddleware() {
     return this.proxyMiddleware;
   }
+  getId() {
+    return this.id;
+  }
+  editSniffer(newConfig: SnifferConfig) {
+    this.changeConfig(newConfig)
+    this.id = newConfig.port.toString()
+    this.config.id = newConfig.port.toString()
+  }
 }


### PR DESCRIPTION
I've noticed that the sniffers data (config etc...) on the client side is changing due to the `onChange` property of  the `TextField` component, resulting in the loss of a unique identifier (port).
therefore, I've use the port as the id for each sniffer on the client and on the server side as well.